### PR TITLE
Fix the check command (remove the './') for more common environment

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -70,7 +70,7 @@ echo "OK"
 # サンプル・ファイルの暗号化
 # --------------------------
 echo -n "サンプル・ファイルを暗号化しています ... "
-RESULT=`./enc ${USERNAME} ${PATHFILE} 2>$1`
+RESULT=`enc ${USERNAME} ${PATHFILE} 2>$1`
 
 if [[ $? != 0 ]]; then
   echo "NG：サンプル・ファイルの暗号化に失敗しました。"
@@ -83,7 +83,7 @@ echo "OK"
 # サンプル・ファイルの復号
 # ------------------------
 echo -n "暗号ファイルを復号しています ... "
-RESULT=`./dec ${SECRETKEY} ${PATHFILE}.enc ${PATHFILE}.dec 2>$1`
+RESULT=`dec ${SECRETKEY} ${PATHFILE}.enc ${PATHFILE}.dec 2>$1`
 
 if [[ $? != 0 ]]; then
   echo "NG：暗号ファイルの復号中にエラーが発生しました。"


### PR DESCRIPTION
binディレクトリを$PATHに設定し、その状態でcheckコマンドを実行した時にエラーになったため、それの修正です（おそらくbinディレクトリにcdして実行した場合は修正前でも動くのだと思いますが）。

こちらも採用・不採用はおまかせします。