### PR TITLE
check コマンドの標準エラーのリダイレクト先を修正

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -78,7 +78,7 @@ echo "OK"
 # サンプル・ファイルの暗号化
 # --------------------------
 echo -n "サンプル・ファイルを暗号化しています ... "
-RESULT=`enc ${USERNAME} ${PATHFILE} 2>$1`
+RESULT=`enc ${USERNAME} ${PATHFILE} 2>&1`
 
 if [[ $? != 0 ]]; then
   echo "NG：サンプル・ファイルの暗号化に失敗しました。"
@@ -91,7 +91,7 @@ echo "OK"
 # サンプル・ファイルの復号
 # ------------------------
 echo -n "暗号ファイルを復号しています ... "
-RESULT=`dec ${SECRETKEY} ${PATHFILE}.enc ${PATHFILE}.dec 2>$1`
+RESULT=`dec ${SECRETKEY} ${PATHFILE}.enc ${PATHFILE}.dec 2>&1`
 
 if [[ $? != 0 ]]; then
   echo "NG：暗号ファイルの復号中にエラーが発生しました。"


### PR DESCRIPTION
fixed #10 

上記 issue の対応です。

とりあえず `2>&1` が正しいものとして PR を送ります。
対応内容が違うようであれば修正します。

よろしくお願いします。