### PR TITLE
#3  shellcheck（静的解析）と shfmt（lint）の実装

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,9 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/alpine/.devcontainer/base.Dockerfile
+
+# [Choice] Alpine version: 3.13, 3.12, 3.11, 3.10
+ARG VARIANT="3.13"
+FROM mcr.microsoft.com/vscode/devcontainers/base:0-alpine-${VARIANT}
+
+# ** [Optional] Uncomment this section to install additional packages. **
+# RUN apk update \
+#     && apk add --no-cache <your-package-list-here>

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -4,6 +4,7 @@
 ARG VARIANT="3.13"
 FROM mcr.microsoft.com/vscode/devcontainers/base:0-alpine-${VARIANT}
 
-# ** [Optional] Uncomment this section to install additional packages. **
-# RUN apk update \
-#     && apk add --no-cache <your-package-list-here>
+RUN apk update \
+     && apk add --no-cache \
+        shellcheck \
+        shfmt

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,5 @@
+# 開発用ディレクトリ
+
+このディレクトリは [Docker](https://ja.wikipedia.org/wiki/Docker) の Alpine Linux コンテナ上でスクリプトの開発をするためのものです。
+
+[VSCode](https://code.visualstudio.com/) と、その [Remote - Containers](https://code.visualstudio.com/docs/remote/remote-overview) 拡張機能がインストールされていれば、同じ開発環境を利用することができます。

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/alpine
+{
+	"name": "Alpine",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick an Alpine version: 3.10, 3.11, 3.12, 3.13
+		"args": { "VARIANT": "3.13" }
+	},
+	
+	// Set *default* container specific settings.json values on container create. 
+	"settings": {
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	// Note that some extensions may not work in Alpine Linux. See https://aka.ms/vscode-remote/linux.
+	"extensions": [],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "vscode"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,33 +1,31 @@
 // For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
 // https://github.com/microsoft/vscode-dev-containers/tree/v0.177.0/containers/alpine
 {
-	"name": "Alpine",
-	"build": {
-		"dockerfile": "Dockerfile",
-		// Update 'VARIANT' to pick an Alpine version: 3.10, 3.11, 3.12, 3.13
-		"args": { "VARIANT": "3.13" }
-	},
-	
-	// Set *default* container specific settings.json values on container create. 
-	"settings": {
-		"terminal.integrated.shell.linux": "/bin/bash"
-	},
+    "name": "Alpine",
+    "build": {
+        "dockerfile": "Dockerfile",
+        // Update 'VARIANT' to pick an Alpine version: 3.10, 3.11, 3.12, 3.13
+        "args": { "VARIANT": "3.13" }
+    },
 
-	// Add the IDs of extensions you want installed when the container is created.
-	// Note that some extensions may not work in Alpine Linux. See https://aka.ms/vscode-remote/linux.
-	"extensions": [
-		"foxundermoon.shell-format"
-	],
+    // Set *default* container specific settings.json values on container create.
+    "settings": {
+        "terminal.integrated.shell.linux": "/bin/bash"
+    },
 
-	// Use 'forwardPorts' to make a list of ports inside the container available locally.
-	// "forwardPorts": [],
+    // Add the IDs of extensions you wanït installed when the container is created.
+    // Note that some extensions may not work in Alpine Linux. See https://aka.ms/vscode-remote/linux.
+    "extensions": ["foxundermoon.shell-format", "esbenp.prettier-vscode"],
 
-	// Use 'postCreateCommand' to run commands after the container is created.
-	// "postCreateCommand": "uname -a",
+    // Use 'forwardPorts' to make a list of ports inside the container available locally.
+    // "forwardPorts": [],
 
-	// Uncomment when using a ptrace-based debugger like C++, Go, and Rust
-	// "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+    // Use 'postCreateCommand' to run commands after the container is created.
+    // "postCreateCommand": "uname -a",
 
-	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
-	"remoteUser": "vscode"
+    // Uncomment when using a ptrace-based debugger like C++, Go, and Rust
+    // "runArgs": [ "--cap-add=SYS_PTRACE", "--security-opt", "seccomp=unconfined" ],
+
+    // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+    "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -15,7 +15,9 @@
 
 	// Add the IDs of extensions you want installed when the container is created.
 	// Note that some extensions may not work in Alpine Linux. See https://aka.ms/vscode-remote/linux.
-	"extensions": [],
+	"extensions": [
+		"foxundermoon.shell-format"
+	],
 
 	// Use 'forwardPorts' to make a list of ports inside the container available locally.
 	// "forwardPorts": [],

--- a/.editorconfig
+++ b/.editorconfig
@@ -4,6 +4,7 @@
 
 root = true
 
+# Default/Common settings
 [*]
 indent_style = space
 indent_size = 4
@@ -14,17 +15,20 @@ insert_final_newline = true
 
 # Shell-format
 [*.sh]
-indent_style       = space # shfmt -i=4
-indent_size        = 4     # shfmt -i=4
+indent_style       = space  # shfmt -i=4
+indent_size        = 4      # shfmt -i=4
 shell_variant      = posix  # shfmt -ln=posix
-binary_next_line   = true  # shfmt -bn
-switch_case_indent = true  # shfmt -ci
-space_redirects    = false # shfmt -sr
-keep_padding       = true  # shfmt -kp
-function_next_line = false # disable shfmt -fn
+binary_next_line   = true   # shfmt -bn
+switch_case_indent = true   # shfmt -ci
+space_redirects    = false  # shfmt -sr
+keep_padding       = true   # shfmt -kp
+function_next_line = false  # disable shfmt -fn
 
-[*.{yml,yaml,json}]
-indent_style = space
+[*.json]
 indent_size = 4
-insert_final_newline = true
+quote_type = single
+
+
+[*.{yml,yaml}]
+indent_size = 2
 quote_type = single

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# -----------------------------------------------------------------------------
+#  editorconfig 互換用設定ファイル
+# -----------------------------------------------------------------------------
+
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+# Shell-format
+[*.sh]
+indent_style       = space # shfmt -i=4
+indent_size        = 4     # shfmt -i=4
+shell_variant      = posix  # shfmt -ln=posix
+binary_next_line   = true  # shfmt -bn
+switch_case_indent = true  # shfmt -ci
+space_redirects    = false # shfmt -sr
+keep_padding       = true  # shfmt -kp
+function_next_line = false # disable shfmt -fn
+
+[*.{yml,yaml,json}]
+indent_style = space
+indent_size = 4
+insert_final_newline = true
+quote_type = single

--- a/.github/run-lint.sh
+++ b/.github/run-lint.sh
@@ -1,0 +1,115 @@
+#!/bin/sh
+# =============================================================================
+#  ShellCheck & ShellFormat(shfmt) の一括実行スクリプト
+# =============================================================================
+
+# -----------------------------------------------------------------------------
+#  Constants
+# -----------------------------------------------------------------------------
+PATH_DIR_REPO="$(dirname "$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)")"
+PATH_DIR_BIN="${PATH_DIR_REPO}/bin"
+PATH_DIR_RETURN="$(cd . && pwd)"
+#SUCCESS=0
+FAILURE=1
+
+# 拡張子のないスクリプトファイル一覧（テスト対象リスト）
+LIST_SCRIPT_NO_EXT="archive check dec enc keygen sign verify"
+
+echo '-------------------------------------------------------------------------------'
+echo ' Requirement Check'
+echo '-------------------------------------------------------------------------------'
+
+# ShellCheck のインストールチェック
+which shellcheck 1>/dev/null 2>/dev/null || {
+    echo >&2 "shellcheck がインストールされていません"
+    echo >&2 "参考文献: https://github.com/Qithub-BOT/QiiCipher/issues/3"
+
+    exit $FAILURE
+}
+echo "ShellCheck $(shellcheck --version | grep version:)"
+
+# shfmt のインストールチェック
+which shfmt 1>/dev/null 2>/dev/null || {
+    echo >&2 "shfmt がインストールされていません"
+    echo >&2 "参考文献: https://github.com/Qithub-BOT/QiiCipher/issues/3"
+
+    exit $FAILURE
+}
+echo "shfmt version: $(shfmt --version)"
+
+# -----------------------------------------------------------------------------
+#  Functions
+# -----------------------------------------------------------------------------
+indentStdIn() {
+    indent="\t"
+    while IFS= read -r line; do
+        printf "${indent}%s\n" "${line}"
+    done
+    echo
+}
+
+runShfmt() {
+    printf "%s" '- Shellformat ... '
+
+    runShfmtForShExt && runShfmtForNoExt && echo 'OK'
+}
+
+runShfmtForShExt() {
+    find . -name '*.sh' -type f -print0 | xargs -0 shfmt -d
+}
+
+runShfmtForNoExt() {
+    # shellcheck disable=SC2086
+    set -- $LIST_SCRIPT_NO_EXT
+    while [ -n "$1" ]; do
+        path_file_target="${PATH_DIR_BIN}/${1}"
+        echo "File: ${path_file_target}"
+        shfmt -d "$path_file_target"
+        shift
+    done
+}
+
+runShellCheck() {
+    printf "%s" '- ShellCheck ... '
+
+    runShellCheckShExt && runShellCheckForNoExt && echo 'OK'
+}
+
+runShellCheckShExt() {
+    find . -name '*.sh' -type f -print0 | xargs -0 shellcheck  --external-sources
+}
+
+runShellCheckForNoExt() {
+    # shellcheck disable=SC2086
+    set -- $LIST_SCRIPT_NO_EXT
+    while [ -n "$1" ]; do
+        path_file_target="${PATH_DIR_BIN}/${1}"
+        echo "File: ${path_file_target}"
+        shellcheck --external-sources "$path_file_target"
+        shift
+    done
+}
+
+# -----------------------------------------------------------------------------
+#  Main
+# -----------------------------------------------------------------------------
+# Do not allow undecleared variables and function failure.
+set -eu
+
+cd "$PATH_DIR_REPO" || {
+    echo >&2 "Failed to change dir to: ${PATH_DIR_REPO}"
+
+    exit $FAILURE
+}
+
+echo '-------------------------------------------------------------------------------'
+echo ' Running linters'
+echo '-------------------------------------------------------------------------------'
+runShfmt
+runShellCheck
+
+cd "$PATH_DIR_RETURN" || {
+    echo >&2 "Failed to change dir to: ${PATH_DIR_RETURN}"
+
+    exit $FAILURE
+}

--- a/.github/run-lint.sh
+++ b/.github/run-lint.sh
@@ -54,21 +54,23 @@ runShfmt() {
     runShfmtForShExt && runShfmtForNoExt && echo 'OK'
 }
 
+# 拡張子 .sh ありのスクリプトの shfmt
 runShfmtForShExt() {
     find . -name '*.sh' -type f -print0 | xargs -0 shfmt -d
 }
 
+# 拡張子 .sh なしのスクリプトの shfmt
 runShfmtForNoExt() {
     result=$SUCCESS
 
     # shellcheck disable=SC2086
     set -- $LIST_SCRIPT_NO_EXT
 
-    while [ ! "$1" ]; do
+    while [ "${1:+none}" ]; do
         path_file_target="${PATH_DIR_BIN}/${1}"
 
         shfmt -d "$path_file_target" || {
-            echo "File: ${path_file_target}"
+            echo >&2 "shfmt fail: ${path_file_target}"
             result=$FAILURE
         }
 
@@ -84,20 +86,30 @@ runShellCheck() {
     runShellCheckShExt && runShellCheckForNoExt && echo 'OK'
 }
 
+# 拡張子 .sh ありのスクリプトの shellcheck
 runShellCheckShExt() {
     find . -name '*.sh' -type f -print0 | xargs -0 shellcheck --external-sources
 }
 
+# 拡張子 .sh なしのスクリプトの shellcheck
 runShellCheckForNoExt() {
+    result=$SUCCESS
+
     # shellcheck disable=SC2086
     set -- $LIST_SCRIPT_NO_EXT
-    while [ ! "${1:+none}" ]; do
+
+    while [ "${1:+none}" ]; do
         path_file_target="${PATH_DIR_BIN}/${1}"
 
-        shellcheck --external-sources "$path_file_target"
+        shellcheck --external-sources "$path_file_target" || {
+            echo >&2 "shellcheck fail: ${path_file_target}"
+            result=$FAILURE
+        }
 
         shift
     done
+
+    return $result
 }
 
 # -----------------------------------------------------------------------------

--- a/.github/run-lint.sh
+++ b/.github/run-lint.sh
@@ -9,7 +9,7 @@
 PATH_DIR_REPO="$(dirname "$(cd "$(dirname "${BASH_SOURCE:-$0}")" && pwd)")"
 PATH_DIR_BIN="${PATH_DIR_REPO}/bin"
 PATH_DIR_RETURN="$(cd . && pwd)"
-#SUCCESS=0
+SUCCESS=0
 FAILURE=1
 
 # 拡張子のないスクリプトファイル一覧（テスト対象リスト）
@@ -59,14 +59,23 @@ runShfmtForShExt() {
 }
 
 runShfmtForNoExt() {
+    result=$SUCCESS
+
     # shellcheck disable=SC2086
     set -- $LIST_SCRIPT_NO_EXT
-    while [ -n "$1" ]; do
+
+    while [ ! "$1" ]; do
         path_file_target="${PATH_DIR_BIN}/${1}"
-        echo "File: ${path_file_target}"
-        shfmt -d "$path_file_target"
+
+        shfmt -d "$path_file_target" || {
+            echo "File: ${path_file_target}"
+            result=$FAILURE
+        }
+
         shift
     done
+
+    return $result
 }
 
 runShellCheck() {
@@ -76,16 +85,17 @@ runShellCheck() {
 }
 
 runShellCheckShExt() {
-    find . -name '*.sh' -type f -print0 | xargs -0 shellcheck  --external-sources
+    find . -name '*.sh' -type f -print0 | xargs -0 shellcheck --external-sources
 }
 
 runShellCheckForNoExt() {
     # shellcheck disable=SC2086
     set -- $LIST_SCRIPT_NO_EXT
-    while [ -n "$1" ]; do
+    while [ ! "${1:+none}" ]; do
         path_file_target="${PATH_DIR_BIN}/${1}"
-        echo "File: ${path_file_target}"
+
         shellcheck --external-sources "$path_file_target"
+
         shift
     done
 }
@@ -93,7 +103,6 @@ runShellCheckForNoExt() {
 # -----------------------------------------------------------------------------
 #  Main
 # -----------------------------------------------------------------------------
-# Do not allow undecleared variables and function failure.
 set -eu
 
 cd "$PATH_DIR_REPO" || {

--- a/.github/workflows/shellcheck_linux.yml
+++ b/.github/workflows/shellcheck_linux.yml
@@ -23,13 +23,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-go-
 
-      - name: Download Modules
-        if: steps.cache.outputs.cache-hit != 'true'
-        run: go mod download
-
       - name: Install latest shfmt
-        run: |
-          GO111MODULE=on go get mvdan.cc/sh/v3/cmd/shfmt
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: GO111MODULE=on go get mvdan.cc/sh/v3/cmd/shfmt
 
       - name: Run shfmt and shellcheck
         run: |

--- a/.github/workflows/shellcheck_linux.yml
+++ b/.github/workflows/shellcheck_linux.yml
@@ -1,0 +1,36 @@
+name: shellcheck
+
+on:
+  workflow_dispatch:
+  pull_request:
+
+jobs:
+  lint_check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v2
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: 1.15.x
+
+      - name: Use Cache for Go
+        uses: actions/cache@v2
+        with:
+          path: ~/go/pkg/mod
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Download Modules
+        if: steps.cache.outputs.cache-hit != 'true'
+        run: go mod download
+
+      - name: Install latest shfmt
+        run: |
+          GO111MODULE=on go get mvdan.cc/sh/v3/cmd/shfmt
+
+      - name: Run shfmt and shellcheck
+        run: |
+          ./.github/run-lint.sh

--- a/.github/workflows/shellcheck_linux.yml
+++ b/.github/workflows/shellcheck_linux.yml
@@ -15,16 +15,7 @@ jobs:
         with:
           go-version: 1.15.x
 
-      - name: Use Cache for Go
-        uses: actions/cache@v2
-        with:
-          path: ~/go/pkg/mod
-          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
-          restore-keys: |
-            ${{ runner.os }}-go-
-
       - name: Install latest shfmt
-        if: steps.cache.outputs.cache-hit != 'true'
         run: GO111MODULE=on go get mvdan.cc/sh/v3/cmd/shfmt
 
       - name: Run shfmt and shellcheck

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,8 @@
+# =============================================================================
+#  ShellCheck Configuration
+# =============================================================================
+#  See: https://github.com/koalaman/shellcheck/wiki/
+
+# Disable
+#   SC2230: https://github.com/koalaman/shellcheck/wiki/SC2230
+disable=SC2230

--- a/bin/archive
+++ b/bin/archive
@@ -17,77 +17,72 @@
 #
 
 md5s() {
-  if [ -e md5sum ] ; then
-    echo $1 | md5sum
-  elif [ -e md5 ] ; then
-    md5 -q -s $1
-  fi
+    if [ -e md5sum ]; then
+        md5sum <"$1"
+    elif [ -e md5 ]; then
+        md5 -q -s "$1"
+    fi
 }
 
 md5f() {
-  if [ -e md5sum ] ; then
-    cat $1 | md5sum
-  elif [ -e md5 ] ; then
-    md5 -q $1
-  fi
+    if [ -e md5sum ]; then
+        md5sum <"$1"
+    elif [ -e md5 ]; then
+        md5 -q "$1"
+    fi
 }
 
 # ヘルプ表示
 # ----------
-if [[ $# < 1 ]]; then
-  echo
-  echo "ファイルを圧縮して暗号化します。（AES-256-CBC暗号）"
-  echo
-  echo "使い方: $0 <input file> [<output file>]"
-  echo
-  echo "- <input file>  : 圧縮＆暗号化したいファイルのパス"
-  echo
-  echo "[オプション]"
-  echo "- <output file> : 圧縮＆暗号化済みファイルの出力先のパス"
-  echo "                  指定がない場合は <input_file>.gz.aes として出力されます。"
-  echo
-  exit 1
+if [[ $# -lt 1 ]]; then
+    echo
+    echo "ファイルを圧縮して暗号化します。（AES-256-CBC暗号）"
+    echo
+    echo "使い方: $0 <input file> [<output file>]"
+    echo
+    echo "- <input file>  : 圧縮＆暗号化したいファイルのパス"
+    echo
+    echo "[オプション]"
+    echo "- <output file> : 圧縮＆暗号化済みファイルの出力先のパス"
+    echo "                  指定がない場合は <input_file>.gz.aes として出力されます。"
+    echo
+    exit 1
 fi
 
 # コマンド引数取得
 # ----------------
 INPUTFILE=$1
 
-
 # 出力ファイル名設定
 # ------------------
-OUTPUTFILE=$1.tar.gz.aes
+OUTPUTFILE="${1}.tar.gz.aes"
 if [[ $# == 2 ]]; then
-  OUTPUTFILE=$2
+    OUTPUTFILE=$2
 fi
-
 
 # 暗号ファイル保存先ディレクトリの作成
 # ------------------------------------
 echo -n "- アーカイブ用ディレクトリを作成しています ... "
 
-TEMPDIR=./$INPUTFILE-archive/
-mkdir -p $TEMPDIR
+TEMPDIR="./${INPUTFILE}-archive/"
 
-if [[ $? != 0 ]]; then
-  echo "NG：ディレクトリをできませんでした。"
-  echo "- 書き込み権限などを確認してください。"
-  exit 1
+if ! mkdir -p "$TEMPDIR"; then
+    echo "NG：ディレクトリをできませんでした。"
+    echo "- 書き込み権限などを確認してください。"
+    exit 1
 fi
 echo "OK"
-
 
 # パスワードの生成
 # ----------------
 echo -n "- 共通鍵を作成しています ... "
 
-PASSWORD=`md5s $RANDOM`
-echo $PASSWORD>$TEMPDIR$OUTPUTFILE.passwd
+PASSWORD=$(md5s $RANDOM)
 
-if [[ $? != 0 ]]; then
-  echo "NG：ファイルを作成できませんでした。"
-  echo "書き込み権限などを確認してください。"
-  exit 1
+if ! (echo "$PASSWORD" >"${TEMPDIR}${OUTPUTFILE}.passwd"); then
+    echo "NG：ファイルを作成できませんでした。"
+    echo "書き込み権限などを確認してください。"
+    exit 1
 fi
 echo "OK"
 
@@ -95,92 +90,81 @@ echo "OK"
 # ----------------------
 # - 参考文献：https://qiita.com/kite_999/items/cc39179463fd061b2e7d
 echo -n "- ファイルを TAR/GZIP 圧縮 → AES 暗号化します ... "
-tar cz $INPUTFILE | openssl enc -e -aes-256-cbc -salt -k $PASSWORD -out $TEMPDIR$OUTPUTFILE
 
-if [[ $? != 0 ]]; then
-  echo "NG：ファイルを圧縮・暗号化できませんでした。"
-  exit 1
+if ! (tar cz "$INPUTFILE" | openssl enc -e -aes-256-cbc -salt -k "$PASSWORD" -out "${TEMPDIR}${OUTPUTFILE}"); then
+    echo "NG：ファイルを圧縮・暗号化できませんでした。"
+    exit 1
 fi
 echo "OK"
 
-
 echo
-echo "✅ $INPUTFILE の圧縮＆暗号化が完了しました。"
-echo "  - ファイル名：$TEMPDIR$OUTPUTFILE"
-
+echo "✅ ${INPUTFILE} の圧縮＆暗号化が完了しました。"
+echo "  - ファイル名：${TEMPDIR}${OUTPUTFILE}"
 
 echo
 echo "【テスト】共通鍵の動作確認および復号・解凍のテストを行います:"
 echo
 
-
 # 共通鍵の読み込み
 # ----------------
 echo -n "- 共通鍵を読み込んでいます ... "
 
-PASSWORD=`cat $TEMPDIR$OUTPUTFILE.passwd`
-
-if [[ $? != 0 ]]; then
-  echo "NG：共通鍵を読み込めませんでした。"
-  exit 1
+if PASSWORD=$(cat "${TEMPDIR}${OUTPUTFILE}.passwd"); then
+    echo "NG：共通鍵を読み込めませんでした。"
+    exit 1
 fi
 echo "OK"
-
 
 # ファイルの復号テスト
 # --------------------
 echo -n "- 共通鍵でファイルを復号しています ... "
 
-TEMPFILE=$INPUTFILE.tar.gz
-openssl enc -d -aes-256-cbc -salt -k $PASSWORD -in $TEMPDIR$OUTPUTFILE -out $TEMPDIR$TEMPFILE
+TEMPFILE="${INPUTFILE}.tar.gz"
 
-if [[ $? != 0 ]]; then
-  echo "NG：ファイルを復号できませんでした。"
-  exit 1
+if ! openssl enc \
+    -d -aes-256-cbc \
+    -salt \
+    -k "$PASSWORD" \
+    -in "${TEMPDIR}${OUTPUTFILE}" \
+    -out "${TEMPDIR}${TEMPFILE}"; then
+    echo "NG：ファイルを復号できませんでした。"
+    exit 1
 fi
 echo "OK"
-
 
 # 解凍のテスト
 # ------------
 echo -n "- 復号された圧縮ファイルの解凍をしています ... "
 
-tar -C $TEMPDIR -xf $TEMPDIR$TEMPFILE
-
-if [[ $? != 0 ]]; then
-  echo "NG：ファイルを解凍できませんでした。"
-  exit 1
+if ! tar -C "$TEMPDIR" -xf "$TEMPDIR$TEMPFILE"; then
+    echo "NG：ファイルを解凍できませんでした。"
+    exit 1
 fi
 echo "OK"
-
 
 # オリジナルと解凍後の同一テスト
 # ------------------------------
 echo -n "- オリジナルと解凍済みのファイルのハッシュを比較しています ... "
 
-HASHORIGINAL=`md5f $INPUTFILE`
-HASHARCHIVED=`md5f $TEMPDIR$INPUTFILE`
+HASHORIGINAL=$(md5f "$INPUTFILE")
+HASHARCHIVED=$(md5f "$TEMPDIR$INPUTFILE")
 
-if [ $HASHORIGINAL = $HASHARCHIVED ]; then
-  echo "OK"
+if [ "$HASHORIGINAL" = "$HASHARCHIVED" ]; then
+    echo "OK"
 else
-  echo "NG ハッシュ値が一致しません"
-  exit 1
+    echo "NG ハッシュ値が一致しません"
+    exit 1
 fi
-
 
 # 作業ファイルの削除
 # ------------------
 echo -n "- 作業ファイルの削除をしています ... "
 
-rm -f $TEMPDIR$TEMPFILE
-rm -f $TEMPDIR$INPUTFILE
-if [[ $? != 0 ]]; then
-  echo "NG：作業ファイルを削除できませんでした。"
-  exit 1
+if ! (rm -f "$TEMPDIR$TEMPFILE" && rm -f "$TEMPDIR$INPUTFILE"); then
+    echo "NG：作業ファイルを削除できませんでした。"
+    exit 1
 fi
 echo "OK"
-
 
 # 終了表示
 # --------
@@ -195,7 +179,7 @@ echo
 echo "‼️ 注意 ‼️"
 echo "共通鍵は平文であるため、相手の公開鍵で暗号化して送ることを強くおすすめします。"
 echo "GitHub の公開鍵を使った暗号化は enc コマンドを利用ください。"
-echo 
+echo
 
 exit 0
 

--- a/bin/check
+++ b/bin/check
@@ -112,7 +112,7 @@ echo "OK"
 # ----------------------
 echo -n "サンプル・ファイルの削除中 ... "
 
-if ! ( rm "$PATHFILE" && rm "${PATHFILE}.enc" ); then
+if ! (rm "$PATHFILE" && rm "${PATHFILE}.enc"); then
     echo "NG：一時ファイルの削除に失敗しました。 手動で削除してください。"
     echo "ファイル名： ${PATHFILE}"
     exit 1

--- a/bin/check
+++ b/bin/check
@@ -18,31 +18,29 @@
 #
 
 md5r() {
-  if [ -e md5sum ] ; then
-    echo $RANDOM | md5sum
-  elif [ -e md5 ] ; then
-    md5 -q -s $RANDOM
-  fi
+    if [ -e md5sum ]; then
+        echo $RANDOM | md5sum
+    elif [ -e md5 ]; then
+        md5 -q -s $RANDOM
+    fi
 }
 
 # ヘルプ表示
 # ----------
-if [[ $# < 2 ]]; then
-  echo
-  echo "使い方: $0 <github user> <id_rsa>"
-  echo
-  echo "- <github user> : あなたの GitHub アカウント名"
-  echo "- <id_rsa>      : GitHub で公開している公開鍵のペアとなる秘密鍵のパス"
-  echo
-  exit 1
+if [[ $# -lt 2 ]]; then
+    echo
+    echo "使い方: ${0} <github user> <id_rsa>"
+    echo
+    echo "- <github user> : あなたの GitHub アカウント名"
+    echo "- <id_rsa>      : GitHub で公開している公開鍵のペアとなる秘密鍵のパス"
+    echo
+    exit 1
 fi
-
 
 # コマンド引数取得
 # ----------------
 USERNAME=$1
 SECRETKEY=$2
-
 
 # trap の設定
 # -----------
@@ -50,87 +48,76 @@ SECRETKEY=$2
 # - 参考URL ： https://qiita.com/m-yamashita/items/889c116b92dc0bf4ea7d
 trap "rm -rf ./sample.*" 0
 
-
 # サンプル・テキストの作成
 # ------------------------
-SAMPLETEXT=`md5r`
+SAMPLETEXT=$(md5r)
 SAMPLETEXT='hoge'
 
 # サンプル・ファイル名設定
 # ------------------------
-FILENAME=`md5r`
+FILENAME=$(md5r)
 PATHFILE="./sample.${FILENAME}.txt"
-
 
 # サンプル・ファイルの作成
 # ------------------------
 echo -n "サンプル・ファイルを作成しています ... "
-echo $SAMPLETEXT > $PATHFILE
 
-if [[ $? != 0 ]]; then
-  echo "NG：サンプル・ファイルの作成に失敗しました。"
-  echo "サンプル・ファイル名： ${PATHFILE}"
-  exit 1
+if ! echo $SAMPLETEXT >"$PATHFILE"; then
+    echo "NG：サンプル・ファイルの作成に失敗しました。"
+    echo "サンプル・ファイル名： ${PATHFILE}"
+    exit 1
 fi
 echo "OK"
-
 
 # サンプル・ファイルの暗号化
 # --------------------------
 echo -n "サンプル・ファイルを暗号化しています ... "
-RESULT=`enc ${USERNAME} ${PATHFILE} 2>&1`
 
-if [[ $? != 0 ]]; then
-  echo "NG：サンプル・ファイルの暗号化に失敗しました。"
-  echo "スクリプトの実行権限、ディレクトリの書き込み権限などを確認ください。"
-  exit 1
+if ! RESULT=$(enc "$USERNAME" "$PATHFILE" 2>&1); then
+    echo "NG：サンプル・ファイルの暗号化に失敗しました。"
+    echo "スクリプトの実行権限、ディレクトリの書き込み権限などを確認ください。"
+    exit 1
 fi
 echo "OK"
-
 
 # サンプル・ファイルの復号
 # ------------------------
 echo -n "暗号ファイルを復号しています ... "
-RESULT=`dec ${SECRETKEY} ${PATHFILE}.enc ${PATHFILE}.dec 2>&1`
 
-if [[ $? != 0 ]]; then
-  echo "NG：暗号ファイルの復号中にエラーが発生しました。"
-  echo "スクリプトの実行権限、ディレクトリの書き込み権限などを確認ください。"
-  exit 1
+if ! RESULT=$(dec "$SECRETKEY" "${PATHFILE}.enc" "${PATHFILE}.dec" 2>&1); then
+    echo "NG：暗号ファイルの復号中にエラーが発生しました。"
+    echo "スクリプトの実行権限、ディレクトリの書き込み権限などを確認ください。"
+    echo "Error: ${RESULT}"
+    exit 1
 fi
 echo "OK"
-
 
 # サンプル・ファイルの比較
 # ------------------------
 echo -n "オリジナルと復号ファイルを比較しています ... "
 
-diff $PATHFILE $PATHFILE.dec
-
-if [[ $? != 0 ]]; then
-  echo "NG：オリジナルと復号されたファイルが異なります。"
-  echo "オリジナル："
-  cat $PATHFILE; echo
-  echo "復号："
-  cat $PATHFILE.dec; echo
-  exit 1
+if ! diff "$PATHFILE" "${PATHFILE}.dec"; then
+    echo "NG：オリジナルと復号されたファイルが異なります。"
+    echo "オリジナル："
+    cat "${PATHFILE}"
+    echo
+    echo "復号："
+    cat "${PATHFILE}.dec"
+    echo
+    exit 1
 fi
 echo "OK"
-
 
 # サンプル・ファイルの削除
 # ----------------------
 echo -n "サンプル・ファイルの削除中 ... "
-rm $PATHFILE
-rm $PATHFILE.enc
 
-if [[ $? != 0 ]]; then
-  echo "NG：一時ファイルの削除に失敗しました。 手動で削除してください。"
-  echo "ファイル名： ${PATHFILE}"
-  exit 1
+if ! ( rm "$PATHFILE" && rm "${PATHFILE}.enc" ); then
+    echo "NG：一時ファイルの削除に失敗しました。 手動で削除してください。"
+    echo "ファイル名： ${PATHFILE}"
+    exit 1
 fi
 echo "OK"
-
 
 # 終了表示
 # --------
@@ -138,4 +125,3 @@ echo
 echo "暗号化・復号のテストを終了しました。"
 echo "✅ 問題なさそうです。"
 echo
-

--- a/bin/dec
+++ b/bin/dec
@@ -15,17 +15,16 @@
 
 # ヘルプ表示
 # ----------
-if [[ $# < 3 ]]; then
-  echo
-  echo "使い方: $0 <private key> <input file> <output file>"
-  echo
-  echo "- <private key> : GitHub で公開している公開鍵のペアとなる秘密鍵のパス"
-  echo "- <input file>  : 暗号化されたファイルのパス"
-  echo "- <output file> : 復号/平文化されるファイルのパス"
-  echo
-  exit 1
+if [[ $# -lt 3 ]]; then
+    echo
+    echo "使い方: $0 <private key> <input file> <output file>"
+    echo
+    echo "- <private key> : GitHub で公開している公開鍵のペアとなる秘密鍵のパス"
+    echo "- <input file>  : 暗号化されたファイルのパス"
+    echo "- <output file> : 復号/平文化されるファイルのパス"
+    echo
+    exit 1
 fi
-
 
 # コマンド引数取得
 # ----------------
@@ -33,24 +32,21 @@ SECRETKEY=$1
 INPUTFILE=$2
 OUTPUTFILE=$3
 
-
 # テキストへ復号
 # --------------
 # 参考URL ： https://qiita.com/kunichiko/items/3c0b1a2915e9dacbd4c1
 echo -n "ファイルを復号しています ... "
-openssl rsautl -decrypt -inkey $SECRETKEY -in $INPUTFILE -out $OUTPUTFILE
 
-if [[ $? != 0 ]]; then
-  echo "NG：復号中にエラーが発生しました。以下の内容が考えられます。"
-  echo " - 暗号ファイルが渡されていない"
-  echo " - 暗号化に使われた公開鍵と違うペアの秘密鍵を使っている"
-  echo " - 1 ブロック以上のデータ（長すぎる暗号データ）を復号している"
-  echo "[注意]:"
-  echo "GitHub で公開されている公開鍵のうち 1 番上の公開鍵のペアの秘密鍵を使っているか確認してください。'check.sh'スクリプトで動作確認をおすすめします。"
-  exit 1
+if ! openssl rsautl -decrypt -inkey "$SECRETKEY" -in "$INPUTFILE" -out "$OUTPUTFILE"; then
+    echo "NG：復号中にエラーが発生しました。以下の内容が考えられます。"
+    echo " - 暗号ファイルが渡されていない"
+    echo " - 暗号化に使われた公開鍵と違うペアの秘密鍵を使っている"
+    echo " - 1 ブロック以上のデータ（長すぎる暗号データ）を復号している"
+    echo "[注意]:"
+    echo "GitHub で公開されている公開鍵のうち 1 番上の公開鍵のペアの秘密鍵を使っているか確認してください。'check.sh'スクリプトで動作確認をおすすめします。"
+    exit 1
 fi
 echo "OK"
-
 
 # 終了表示
 # --------

--- a/bin/enc
+++ b/bin/enc
@@ -15,27 +15,27 @@
 
 # ヘルプ表示
 # ----------
-if [[ $# < 2 ]]; then
-  echo
-  echo "使い方: $0 <github user> <input file> [<output file>]"
-  echo
-  echo "- <github user> : 相手の GitHub アカウント名"
-  echo "- <input file>  : 暗号化したいファイルのパス"
-  echo "[オプション]"
-  echo "- <output file> : 暗号化されたファイルの出力先のパス"
-  echo "                  指定がない場合は <input_file>.enc として出力されます。"
-  echo "[注意]"
-  echo "- このスクリプトは 1 ブロックぶんのデータのみ暗号化できます。"
-  echo
-  exit 1
+if [[ $# -lt 2 ]]; then
+    echo
+    echo "使い方: $0 <github user> <input file> [<output file>]"
+    echo
+    echo "- <github user> : 相手の GitHub アカウント名"
+    echo "- <input file>  : 暗号化したいファイルのパス"
+    echo "[オプション]"
+    echo "- <output file> : 暗号化されたファイルの出力先のパス"
+    echo "                  指定がない場合は <input_file>.enc として出力されます。"
+    echo "[注意]"
+    echo "- このスクリプトは 1 ブロックぶんのデータのみ暗号化できます。"
+    echo
+    exit 1
 fi
 
 md5s() {
-  if [ -e md5sum ] ; then
-    echo $1 | md5sum
-  elif [ -e md5 ] ; then
-    md5 -q -s $1
-  fi
+    if [ -e md5sum ]; then
+        echo "$1" | md5sum
+    elif [ -e md5 ]; then
+        md5 -q -s "$1"
+    fi
 }
 
 # コマンド引数取得
@@ -43,26 +43,23 @@ md5s() {
 USERNAME=$1
 INPUTFILE=$2
 
-
 # 出力ファイル名設定
 # ------------------
 OUTPUTFILE=$2.enc
 if [[ $# == 3 ]]; then
-  OUTPUTFILE=$3
+    OUTPUTFILE=$3
 fi
-
 
 # trap の設定
 # -----------
 # スクリプト終了後一時ファイルを削除します。
 # - 参考URL ： https://qiita.com/m-yamashita/items/889c116b92dc0bf4ea7d
-trap "rm -rf /tmp/$USERNAME.*" 0
-
+trap 'rm -rf /tmp/${USERNAME}.*' 0
 
 # 一時ファイル
 # ------------
-TMP=`md5s $RANDOM`
-PATHPUBKEY=/tmp/$USERNAME.$TMP.pub
+TMP=$(md5s $RANDOM)
+PATHPUBKEY="/tmp/${USERNAME}.${TMP}.pub"
 
 # RSA 公開鍵の取得
 # ----------------
@@ -71,14 +68,11 @@ PATHPUBKEY=/tmp/$USERNAME.$TMP.pub
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
 echo -n "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
-curl -s https://github.com/$USERNAME.keys | head -n 1 > $PATHPUBKEY
-
-if [[ $? != 0 ]]; then
-  echo "NG：公開鍵を取得・保存できませんでした。"
-  exit 1
+if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
+    echo "NG：公開鍵を取得・保存できませんでした。"
+    exit 1
 fi
 echo "OK"
-
 
 # 公開鍵のフォーマット変換
 # ------------------------
@@ -87,14 +81,11 @@ echo "OK"
 #   - https://qiita.com/connvoi_tyou/items/3e86b6b68c3f398b3244
 echo -n "RSA 形式の公開鍵を PKCS8 形式に変換中 ... "
 
-ssh-keygen -f $PATHPUBKEY -e -m pkcs8 > $PATHPUBKEY.pkcs8
-
-if [[ $? != 0 ]]; then
-  echo "NG：RSA -> PKCS8 変換中にエラーが発生しました。"
-  exit 1
+if ! ssh-keygen -f "$PATHPUBKEY" -e -m pkcs8 >"${PATHPUBKEY}.pkcs8"; then
+    echo "NG：RSA -> PKCS8 変換中にエラーが発生しました。"
+    exit 1
 fi
 echo "OK"
-
 
 # テキストの暗号化
 # ----------------
@@ -108,24 +99,25 @@ echo "OK"
 #       4096 =  502
 #       8192 = 1018
 echo -n "公開鍵でファイルを暗号化中 ... "
-openssl rsautl -encrypt -pubin -inkey $PATHPUBKEY.pkcs8 -in $INPUTFILE -out $OUTPUTFILE
 
-if [[ $? != 0 ]]; then
-  echo "NG：暗号化に失敗しました。ファイルのサイズなど、エラー内容を確認ください。"
-  exit 1
+if ! openssl rsautl \
+    -encrypt \
+    -pubin \
+    -inkey "${PATHPUBKEY}.pkcs8" \
+    -in "$INPUTFILE" \
+    -out "$OUTPUTFILE"; then
+    echo "NG：暗号化に失敗しました。ファイルのサイズなど、エラー内容を確認ください。"
+    exit 1
 fi
 echo "OK"
-
 
 # 一時ファイルの削除
 # ------------------
 echo -n "一時ファイルの削除中 ... "
-rm $PATHPUBKEY
-rm $PATHPUBKEY.pkcs8
 
-if [[ $? != 0 ]]; then
-  echo "NG：一時ファイルの削除に失敗しました。 '/tmp/' ディレクトリ内を手動で削除してください。"
-  exit 1
+if ! (rm "$PATHPUBKEY" && rm "${PATHPUBKEY}.pkcs8"); then
+    echo "NG：一時ファイルの削除に失敗しました。 '/tmp/' ディレクトリ内を手動で削除してください。"
+    exit 1
 fi
 echo "OK"
 

--- a/bin/keygen
+++ b/bin/keygen
@@ -15,24 +15,24 @@
 
 # ヘルプ表示
 # ----------
-if [[ $# < 2 ]]; then
-  echo
-  echo "使い方: $0 <email> <keyname>"
-  echo
-  echo "- <email> : Githubで使用しているメールアドレス(公開鍵内に埋め込まれます)"
-  echo "- <keyname>  : 希望するキーペアの名前(パス名ではない)"
-  echo
-  exit 1
+if [[ $# -lt 2 ]]; then
+    echo
+    echo "使い方: $0 <email> <keyname>"
+    echo
+    echo "- <email> : Githubで使用しているメールアドレス(公開鍵内に埋め込まれます)"
+    echo "- <keyname>  : 希望するキーペアの名前(パス名ではない)"
+    echo
+    exit 1
 fi
 
-if [ ! -d ~/.ssh ] ;  then
-  mkdir ~/.ssh
-  chmod 700 ~/.ssh
+if [ ! -d ~/.ssh ]; then
+    mkdir ~/.ssh
+    chmod 700 ~/.ssh
 fi
 
-ssh-keygen -t rsa -b 4096 -m PEM -C $1 -f ~/.ssh/$2
+ssh-keygen -t rsa -b 4096 -m PEM -C "$1" -f ~/.ssh/"$2"
 
 echo
 echo "This is the generated pubkey. Register it on your github account. Then try the 'check' command for error check."
 echo
-cat ~/.ssh/$2.pub
+cat ~/.ssh/"${2}.pub"

--- a/bin/sign
+++ b/bin/sign
@@ -4,7 +4,7 @@
 # ======================================
 #
 # RSA 秘密鍵を使いファイルに署名（電子署名ファイルの生成を）します。
-# 
+#
 # GitHub 上で公開されている（https://github.com/<user name>.keys で取得できる）
 # 自身の RSA 公開鍵とペアの秘密鍵である必要があります。
 #
@@ -17,27 +17,27 @@
 
 # ヘルプ表示
 # ----------
-if [[ $# < 2 ]]; then
-  echo
-  echo "使い方: $0 <github user> <private key> <input file> [<output file>]"
-  echo
-  echo "- <github user> : 自分の GitHub アカウント名"
-  echo "- <private key> : GitHub で公開している公開鍵のペアとなる秘密鍵のパス"
-  echo "- <input file>  : 署名したいファイルのパス"
-  echo
-  echo "[オプション]"
-  echo "- <output file> : 署名ファイルの出力先のパス"
-  echo "                  指定がない場合は <input_file>.sig として出力されます。"
-  echo
-  exit 1
+if [[ $# -lt 2 ]]; then
+    echo
+    echo "使い方: ${0} <github user> <private key> <input file> [<output file>]"
+    echo
+    echo "- <github user> : 自分の GitHub アカウント名"
+    echo "- <private key> : GitHub で公開している公開鍵のペアとなる秘密鍵のパス"
+    echo "- <input file>  : 署名したいファイルのパス"
+    echo
+    echo "[オプション]"
+    echo "- <output file> : 署名ファイルの出力先のパス"
+    echo "                  指定がない場合は <input_file>.sig として出力されます。"
+    echo
+    exit 1
 fi
 
 md5s() {
-  if [ -e md5sum ] ; then
-    echo $1 | md5sum
-  elif [ -e md5 ] ; then
-    md5 -q -s $1
-  fi
+    if [ -e md5sum ]; then
+        echo "$1" | md5sum
+    elif [ -e md5 ]; then
+        md5 -q -s "$1"
+    fi
 }
 
 # コマンド引数取得
@@ -46,36 +46,33 @@ USERNAME=$1
 PRIVATEKEY=$2
 INPUTFILE=$3
 
-
 # 出力ファイル名設定
 # ------------------
-OUTPUTFILE=$3.sig
+OUTPUTFILE="${3}.sig"
 if [[ $# == 4 ]]; then
-  OUTPUTFILE=$4
+    OUTPUTFILE=$4
 fi
 
 # trap の設定
 # -----------
 # スクリプト終了後一時ファイルを削除します。
 # - 参考URL ： https://qiita.com/m-yamashita/items/889c116b92dc0bf4ea7d
-trap "rm -rf /tmp/$USERNAME.*" 0
-
+trap 'rm -rf /tmp/${USERNAME}.*' 0
 
 # 電子署名の生成
 # --------------
 # - 参考URL ： https://qiita.com/kunichiko/items/3c0b1a2915e9dacbd4c1
 echo -n "ファイル ${INPUTFILE} の署名ファイルを生成中 ... "
 
-openssl dgst -sha1 -sign ${PRIVATEKEY} ${INPUTFILE} > ${OUTPUTFILE}
-
-if [[ $? != 0 ]]; then
-  echo "NG：署名ファイルを生成できませんでした。"
-  exit 1
+if ! openssl dgst -sha1 \
+    -sign "$PRIVATEKEY" \
+    "$INPUTFILE" >"$OUTPUTFILE"; then
+    echo "NG：署名ファイルを生成できませんでした。"
+    exit 1
 fi
 
 echo "OK"
 echo "✅ ${INPUTFILE} の電子署名が作成されました。"
-
 
 # [電子署名の検証] -------------------------------------------------------------
 
@@ -85,8 +82,8 @@ echo
 
 # 一時ファイル
 # ------------
-TMP=`md5s $RANDOM`
-PATHPUBKEY=/tmp/$USERNAME.$TMP.pub
+TMP=$(md5s $RANDOM)
+PATHPUBKEY="/tmp/${USERNAME}.${TMP}.pub"
 
 # RSA 公開鍵の取得
 # ----------------
@@ -95,14 +92,11 @@ PATHPUBKEY=/tmp/$USERNAME.$TMP.pub
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
 echo -n "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
-curl -s https://github.com/$USERNAME.keys | head -n 1 > $PATHPUBKEY
-
-if [[ $? != 0 ]]; then
-  echo "NG：公開鍵を取得・保存できませんでした。"
-  exit 1
+if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
+    echo "NG：公開鍵を取得・保存できませんでした。"
+    exit 1
 fi
 echo "OK"
-
 
 # 公開鍵のフォーマット変換
 # ------------------------
@@ -111,29 +105,27 @@ echo "OK"
 #   - https://qiita.com/connvoi_tyou/items/3e86b6b68c3f398b3244
 echo -n "RSA 形式の公開鍵を PKCS8 形式に変換中 ... "
 
-ssh-keygen -f $PATHPUBKEY -e -m pkcs8 > $PATHPUBKEY.pkcs8
-
-if [[ $? != 0 ]]; then
-  echo "NG：RSA -> PKCS8 変換中にエラーが発生しました。"
-  exit 1
+if ! ssh-keygen -f "$PATHPUBKEY" -e -m pkcs8 >"${PATHPUBKEY}.pkcs8"; then
+    echo "NG：RSA -> PKCS8 変換中にエラーが発生しました。"
+    exit 1
 fi
 echo "OK"
-
 
 # 電子署名の検証
 # --------------
 # - 参考URL ： https://qiita.com/kunichiko/items/3c0b1a2915e9dacbd4c1
 echo -n "ファイル ${INPUTFILE} の署名ファイルを検証中 ... "
 
-openssl dgst -sha1 -verify ${PATHPUBKEY}.pkcs8 -signature ${OUTPUTFILE} ${INPUTFILE}
-
-if [[ $? != 0 ]]; then
-  echo "NG：署名ファイルを検証できませんでした。"
-  exit 1
+if ! openssl dgst \
+    -sha1 \
+    -verify "${PATHPUBKEY}.pkcs8" \
+    -signature "${OUTPUTFILE}" \
+    "${INPUTFILE}"; then
+    echo "NG：署名ファイルを検証できませんでした。"
+    exit 1
 fi
 
 echo "✅ 電子署名ファイルの検証が完了しました"
-
 
 # 終了表示
 # --------

--- a/bin/verify
+++ b/bin/verify
@@ -16,39 +16,38 @@
 
 # ヘルプ表示
 # ----------
-if [[ $# < 2 ]]; then
-  echo
-  echo "使い方: ${0} <verify file> <github user> [<sign file>]"
-  echo
-  echo "- <verify file> : 確認したいファイル"
-  echo "- <github user> : 署名者の GitHub アカウント名"
-  echo
-  echo "[オプション]"
-  echo "- <sign file>   : 電子署名ファイルのパス"
-  echo "                  指定がない場合は同階層の <verify file>.sig が使用されます。"
-  echo
-  exit 1
+if [[ $# -lt 2 ]]; then
+    echo
+    echo "使い方: ${0} <verify file> <github user> [<sign file>]"
+    echo
+    echo "- <verify file> : 確認したいファイル"
+    echo "- <github user> : 署名者の GitHub アカウント名"
+    echo
+    echo "[オプション]"
+    echo "- <sign file>   : 電子署名ファイルのパス"
+    echo "                  指定がない場合は同階層の <verify file>.sig が使用されます。"
+    echo
+    exit 1
 fi
 
 md5s() {
-  if [ -e md5sum ] ; then
-    echo $1 | md5sum
-  elif [ -e md5 ] ; then
-    md5 -q -s $1
-  fi
+    if [ -e md5sum ]; then
+        echo "$1" | md5sum
+    elif [ -e md5 ]; then
+        md5 -q -s "$1"
+    fi
 }
 
 # コマンド引数取得
 # ----------------
-VERIFYFILE=$1
-USERNAME=$2
-
+VERIFYFILE="$1"
+USERNAME="$2"
 
 # 出力ファイル名設定
 # ------------------
-SIGNFILE=$1.sig
+SIGNFILE="${1}.sig"
 if [[ $# == 3 ]]; then
-  SIGNFILE=$3
+    SIGNFILE="$3"
 fi
 
 # trap の設定
@@ -57,10 +56,9 @@ fi
 # - 参考URL ：
 #     https://qiita.com/m-yamashita/items/889c116b92dc0bf4ea7d
 #     https://qiita.com/bsdhack/items/47c9cbb5fd22fcc9597a
-TMPDIR=${TMP:-/tmp}/`basename ${0}`-`md5s ${RANDOM}`
-mkdir -p ${TMPDIR}
+TMPDIR="${TMP:-/tmp}/$(basename "${0}")-$(md5s ${RANDOM})"
+mkdir -p "$TMPDIR"
 trap 'rm -r ${TMPDIR}' 0
-
 
 # [電子署名の検証] -------------------------------------------------------------
 
@@ -70,8 +68,7 @@ echo
 
 # 一時ファイル
 # ------------
-PATHPUBKEY=${TMPDIR}/${USERNAME}.pub
-
+PATHPUBKEY="${TMPDIR}/${USERNAME}.pub"
 
 # RSA 公開鍵の取得
 # ----------------
@@ -80,14 +77,11 @@ PATHPUBKEY=${TMPDIR}/${USERNAME}.pub
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
 echo -n "- ${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
-curl -s https://github.com/$USERNAME.keys | head -n 1 > $PATHPUBKEY
-
-if [[ $? != 0 ]]; then
-  echo "NG：公開鍵を取得・保存できませんでした。"
-  exit 1
+if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
+    echo "NG：公開鍵を取得・保存できませんでした。"
+    exit 1
 fi
 echo "OK"
-
 
 # 公開鍵のフォーマット変換
 # ------------------------
@@ -96,39 +90,35 @@ echo "OK"
 #   - https://qiita.com/connvoi_tyou/items/3e86b6b68c3f398b3244
 echo -n "- RSA 形式の公開鍵を PKCS8 形式に変換中 ... "
 
-ssh-keygen -f $PATHPUBKEY -e -m pkcs8 > $PATHPUBKEY.pkcs8
-
-if [[ $? != 0 ]]; then
-  echo "NG：RSA -> PKCS8 変換中にエラーが発生しました。"
-  exit 1
+if ! ssh-keygen -f "$PATHPUBKEY" -e -m pkcs8 >"${PATHPUBKEY}.pkcs8"; then
+    echo "NG：RSA -> PKCS8 変換中にエラーが発生しました。"
+    exit 1
 fi
 echo "OK"
-
 
 # 電子署名の検証
 # --------------
 # - 参考URL ： https://qiita.com/kunichiko/items/3c0b1a2915e9dacbd4c1
 echo -n "- ファイル ${VERIFYFILE} の署名ファイルを検証中 ... "
 
-openssl dgst -sha1 -verify ${PATHPUBKEY}.pkcs8 -signature ${SIGNFILE} ${VERIFYFILE}
-
-
-if [[ $? != 0 ]]; then
-  echo
-  echo "NG：署名ファイルを検証できませんでした。以下のいずれかが署名時と異なります。"
-  echo "- 対象ファイル： ${VERIFYFILE}"
-  echo "- 署名ファイル： ${SIGNFILE}"
-  echo "- 署名者      ： ${USERNAME}（署名時の鍵が異なる）"
-  echo
-  exit 1
+if ! openssl dgst -sha1 \
+    -verify "${PATHPUBKEY}.pkcs8" \
+    -signature "$SIGNFILE" \
+    "$VERIFYFILE"; then
+    echo
+    echo "NG：署名ファイルを検証できませんでした。以下のいずれかが署名時と異なります。"
+    echo "- 対象ファイル： ${VERIFYFILE}"
+    echo "- 署名ファイル： ${SIGNFILE}"
+    echo "- 署名者     ： ${USERNAME}（署名時の鍵が異なる）"
+    echo
+    exit 1
 fi
-
 
 # 終了表示
 # --------
 echo
 echo "✅ 署名の検証を完了しました。このファイルは正しく署名されています。"
 echo "- 対象ファイル： ${VERIFYFILE}"
-echo "- 署名者      ： ${USERNAME}"
+echo "- 署名者     ： ${USERNAME}"
 echo
 exit 0


### PR DESCRIPTION
Issue #3 の実装です。

~~とりあえず、この[ドラフト PR](https://github.blog/jp/2019-02-19-introducing-draft-pull-requests/) で以下を実装します 。~~

実装（？）してみました。Merge されないと GitHub Actions の動画確認できないっぽい ... Fork 先でも何かできませんでした。

### すること

- [x] 再現・開発用の Dockerfile （現在 Alpine Linux）
- [x] shellcheck および shfmt の実行スクリプト（`./.github/run-lint.sh`）
- [x] 初回 shellceck および shfmt の修正
- [x] GitHub Action による shellceck および shfmt のテスト

### しないこと

- 静的解析と lint の修正を除く既存スクリプトのリファクタリング（関数化など）
- 各スクリプトファイルにある関数の単体テスト
- 新たな機能追加
