### PR TITLE
sign コマンドで失敗時に `*.sig` ファイルを削除する

### DIFF
--- a/bin/sign
+++ b/bin/sign
@@ -76,6 +76,7 @@ if ! openssl dgst -sha1 \
     -sign "$PRIVATEKEY" \
     "$INPUTFILE" >"$OUTPUTFILE"; then
     echo "NG：署名ファイルを生成できませんでした。"
+    rm -f "$OUTPUTFILE"
     exit 1
 fi
 

--- a/tests/issues/issue34_test.sh
+++ b/tests/issues/issue34_test.sh
@@ -1,0 +1,17 @@
+#shellcheck shell=sh
+
+Describe 'sign with unexisting key'
+    name_file_to_sign="dummy.txt"
+    path_file_sig_out="${SHELLSPEC_TMPDIR}/${name_file_to_sign}.sig"
+
+    It 'should print err with status 1 and should not create .enc file'
+        When call "${PATH_DIR_BIN}"/sign KEINOS '/path/to/unknown/key.pub' "$name_file_to_sign" "$path_file_sig_out"
+
+        The stdout should include '署名ファイルを生成できませんでした'
+        The stderr should include 'No such file or directory'
+        The status should be failure # status is 1-255
+
+        Path file_sig="$path_file_sig_out"
+        The path file_sig should not be exist
+    End
+End


### PR DESCRIPTION
## 現象

sign コマンドで失敗した場合にも `*.sig` ファイルが作成されてしまう
（終了ステータスコードは正しく失敗扱いとなっている）

参考：

* #31  「verifyがエラーになる？」
* #34 「sign コマンドで失敗しても *.sig ファイルが作成されてしまう」

## 調査と対策方法

現状のソースでは、署名ファイルを標準出力に出力し、リダイレクトでファイルに保存している。
リダイレクトしているため必ずファイルが生成されている可能性があると思われるため、別の方法を検証する。
具体的には `-out 署名ファイル` で実行して署名失敗した場合に、署名ファイルが出力されるか確認する。

```
$ echo test > test
$ openssl dgst -sha1 -sign dummy-private-key -out test.sig test
Can't open dummy-private-key for reading, No such file or directory
140161001227584:error:02001002:system library:fopen:No such file or directory:../crypto/bio/bss_file.c:69:fopen('dummy-private-key','r')
140161001227584:error:2006D080:BIO routines:BIO_new_file:no such file:../crypto/bio/bss_file.c:76:
unable to load key file
$ ls
test  test.sig
$ 
```

調査の結果、出力先を `-out 署名ファイル` で指定して署名に失敗した場合でも、リダイレクトの場合と同様に署名ファイルが出力されることがわかった。
そのため署名ファイルの出力方法は現状通り（リダイレクト）で、署名失敗時にファイルを削除する方法で対策をする。

## 手順

* まず、テストコードのみで PR を送付(shellspec でエラーとなる)
* その後 `sign` コマンドを修正