### PR TITLE
`echo -n "$foo"` を `printf "%s" "$foo"` に変更

### DIFF
--- a/bin/archive
+++ b/bin/archive
@@ -70,7 +70,7 @@ fi
 
 # 暗号ファイル保存先ディレクトリの作成
 # ------------------------------------
-echo -n "- アーカイブ用ディレクトリを作成しています ... "
+printf "%s" "- アーカイブ用ディレクトリを作成しています ... "
 
 TEMPDIR="./$(basename "$INPUTFILE")-archive/"
 
@@ -86,7 +86,7 @@ PASSWORD_PATH="${TEMPDIR}${OUTPUTFILE}.passwd"
 
 # パスワードの生成
 # ----------------
-echo -n "- 共通鍵を作成しています ... "
+printf "%s" "- 共通鍵を作成しています ... "
 
 PASSWORD=$(md5s $RANDOM)
 
@@ -103,7 +103,7 @@ echo "OK"
 # ファイルの圧縮＆暗号化
 # ----------------------
 # - 参考文献：https://qiita.com/kite_999/items/cc39179463fd061b2e7d
-echo -n "- ファイルを TAR/GZIP 圧縮 → AES 暗号化します ... "
+printf "%s" "- ファイルを TAR/GZIP 圧縮 → AES 暗号化します ... "
 
 if ! (tar -C "$(dirname "$INPUTFILE")" -cz "$(basename "$INPUTFILE")" | openssl enc -e -aes-256-cbc -salt -k "$PASSWORD" -out "${ARCHIVE_PATH}"); then
     echo "NG：ファイルを圧縮・暗号化できませんでした。"
@@ -121,7 +121,7 @@ echo
 
 # 共通鍵の読み込み
 # ----------------
-echo -n "- 共通鍵を読み込んでいます ... "
+printf "%s" "- 共通鍵を読み込んでいます ... "
 
 if ! PASSWORD=$(cat "${PASSWORD_PATH}"); then
     echo "NG：共通鍵を読み込めませんでした。"
@@ -131,7 +131,7 @@ echo "OK"
 
 # ファイルの復号テスト
 # --------------------
-echo -n "- 共通鍵でファイルを復号しています ... "
+printf "%s" "- 共通鍵でファイルを復号しています ... "
 
 TEMPFILE="$(basename "$INPUTFILE").tar.gz"
 
@@ -148,7 +148,7 @@ echo "OK"
 
 # 解凍のテスト
 # ------------
-echo -n "- 復号された圧縮ファイルの解凍をしています ... "
+printf "%s" "- 復号された圧縮ファイルの解凍をしています ... "
 
 if ! tar -C "$TEMPDIR" -xf "$TEMPDIR$TEMPFILE"; then
     echo "NG：ファイルを解凍できませんでした。"
@@ -158,7 +158,7 @@ echo "OK"
 
 # オリジナルと解凍後の同一テスト
 # ------------------------------
-echo -n "- オリジナルと解凍済みのファイルのハッシュを比較しています ... "
+printf "%s" "- オリジナルと解凍済みのファイルのハッシュを比較しています ... "
 
 HASHORIGINAL=$(md5f "$INPUTFILE")
 HASHARCHIVED=$(md5f "$TEMPDIR$(basename "$INPUTFILE")")
@@ -172,7 +172,7 @@ fi
 
 # 作業ファイルの削除
 # ------------------
-echo -n "- 作業ファイルの削除をしています ... "
+printf "%s" "- 作業ファイルの削除をしています ... "
 
 if ! (rm -f "$TEMPDIR$TEMPFILE" && rm -f "$TEMPDIR$(basename "$INPUTFILE")"); then
     echo "NG：作業ファイルを削除できませんでした。"

--- a/bin/check
+++ b/bin/check
@@ -61,7 +61,7 @@ PATHFILE="./sample.${FILENAME}.txt"
 
 # サンプル・ファイルの作成
 # ------------------------
-echo -n "サンプル・ファイルを作成しています ... "
+printf "%s" "サンプル・ファイルを作成しています ... "
 
 if ! echo "$SAMPLETEXT" >"$PATHFILE"; then
     echo "NG：サンプル・ファイルの作成に失敗しました。"
@@ -72,7 +72,7 @@ echo "OK"
 
 # サンプル・ファイルの暗号化
 # --------------------------
-echo -n "サンプル・ファイルを暗号化しています ... "
+printf "%s" "サンプル・ファイルを暗号化しています ... "
 
 if ! RESULT=$("$PATH_DIR_BIN"/enc "$USERNAME" "$PATHFILE" 2>&1); then
     echo "NG：サンプル・ファイルの暗号化に失敗しました。"
@@ -83,7 +83,7 @@ echo "OK"
 
 # サンプル・ファイルの復号
 # ------------------------
-echo -n "暗号ファイルを復号しています ... "
+printf "%s" "暗号ファイルを復号しています ... "
 
 if ! RESULT=$("$PATH_DIR_BIN"/dec "$SECRETKEY" "${PATHFILE}.enc" "${PATHFILE}.dec" 2>&1); then
     echo "NG：暗号ファイルの復号中にエラーが発生しました。"
@@ -95,7 +95,7 @@ echo "OK"
 
 # サンプル・ファイルの比較
 # ------------------------
-echo -n "オリジナルと復号ファイルを比較しています ... "
+printf "%s" "オリジナルと復号ファイルを比較しています ... "
 
 if ! diff "$PATHFILE" "${PATHFILE}.dec"; then
     echo "NG：オリジナルと復号されたファイルが異なります。"
@@ -111,7 +111,7 @@ echo "OK"
 
 # サンプル・ファイルの削除
 # ----------------------
-echo -n "サンプル・ファイルの削除中 ... "
+printf "%s" "サンプル・ファイルの削除中 ... "
 
 if ! (rm "$PATHFILE" && rm "${PATHFILE}.enc"); then
     echo "NG：一時ファイルの削除に失敗しました。 手動で削除してください。"

--- a/bin/checkkeylength
+++ b/bin/checkkeylength
@@ -60,7 +60,7 @@ PATHPUBKEY="/tmp/${USERNAME}.${TMP}.pub"
 # ユーザの GitHub の公開鍵一覧の１行目を取得
 # - 取得先は： https://github.com/<user name>.keys
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
-echo -n "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
+printf "%s" "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
 if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
     echo "NG：公開鍵を取得・保存できませんでした。"

--- a/bin/dearchive
+++ b/bin/dearchive
@@ -42,7 +42,7 @@ fi
 # md5s は md5sum/md5 のラッパー関数です.
 md5s() {
     if type md5sum 1>/dev/null 2>/dev/null; then
-        echo "$1" | md5sum | awk '{ print $1 }'
+        printf "%s" "$1" | md5sum | awk '{ print $1 }'
         return $?
     fi
 
@@ -85,7 +85,7 @@ fi
 
 # ファイルの復号テスト
 # --------------------
-echo -n "- 共通鍵でファイルを復号しています ... "
+printf "%s" "- 共通鍵でファイルを復号しています ... "
 
 if ! openssl enc \
     -d -aes-256-cbc \

--- a/bin/dec
+++ b/bin/dec
@@ -35,7 +35,7 @@ OUTPUTFILE=$3
 # テキストへ復号
 # --------------
 # 参考URL ： https://qiita.com/kunichiko/items/3c0b1a2915e9dacbd4c1
-echo -n "ファイルを復号しています ... "
+printf "%s" "ファイルを復号しています ... "
 
 if ! openssl rsautl -decrypt -inkey "$SECRETKEY" -in "$INPUTFILE" -out "$OUTPUTFILE"; then
     echo "NG：復号中にエラーが発生しました。以下の内容が考えられます。"

--- a/bin/enc
+++ b/bin/enc
@@ -92,7 +92,7 @@ PATHPUBKEY="/tmp/${USERNAME}.${TMP}.pub"
 # ユーザの GitHub の公開鍵一覧の１行目を取得
 # - 取得先は： https://github.com/<user name>.keys
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
-echo -n "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
+printf "%s" "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
 if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
     echo >&2 "NG：公開鍵を取得・保存できませんでした。"
@@ -102,7 +102,7 @@ echo "OK"
 
 # 公開鍵のアクセス権変更
 # ------------------
-echo -n "取得した公開鍵のアクセス権を変更中 (0644 -> 0600) ... "
+printf "%s" "取得した公開鍵のアクセス権を変更中 (0644 -> 0600) ... "
 
 if ! chmod 0600 "$PATHPUBKEY"; then
     echo >&2 "NG：ファイルのアクセス権を変更できませんでした。"
@@ -115,7 +115,7 @@ echo "OK"
 # - 参考URL ：
 #   - https://qiita.com/drobune/items/bf5d689eff7f69ed6866
 #   - https://qiita.com/connvoi_tyou/items/3e86b6b68c3f398b3244
-echo -n "RSA 形式の公開鍵を PKCS8 形式に変換中 ... "
+printf "%s" "RSA 形式の公開鍵を PKCS8 形式に変換中 ... "
 
 if ! ssh-keygen -f "$PATHPUBKEY" -e -m pkcs8 >"${PATHPUBKEY}.pkcs8"; then
     echo >&2 "NG：RSA -> PKCS8 変換中にエラーが発生しました。"
@@ -134,7 +134,7 @@ echo "OK"
 #       2048 =  246
 #       4096 =  502
 #       8192 = 1018
-echo -n "公開鍵でファイルを暗号化中 ... "
+printf "%s" "公開鍵でファイルを暗号化中 ... "
 
 if ! openssl rsautl \
     -encrypt \
@@ -149,7 +149,7 @@ echo "OK"
 
 # 一時ファイルの削除
 # ------------------
-echo -n "一時ファイルの削除中 ... "
+printf "%s" "一時ファイルの削除中 ... "
 
 if ! (rm "$PATHPUBKEY" && rm "${PATHPUBKEY}.pkcs8"); then
     echo >&2 "NG：一時ファイルの削除に失敗しました。 '/tmp/' ディレクトリ内を手動で削除してください。"

--- a/bin/sign
+++ b/bin/sign
@@ -70,7 +70,7 @@ trap 'rm -rf /tmp/${USERNAME}.*' 0
 # 電子署名の生成
 # --------------
 # - 参考URL ： https://qiita.com/kunichiko/items/3c0b1a2915e9dacbd4c1
-echo -n "ファイル ${INPUTFILE} の署名ファイルを生成中 ... "
+printf "%s" "ファイル ${INPUTFILE} の署名ファイルを生成中 ... "
 
 if ! openssl dgst -sha1 \
     -sign "$PRIVATEKEY" \
@@ -99,7 +99,7 @@ PATHPUBKEY="/tmp/${USERNAME}.${TMP}.pub"
 # ユーザの GitHub の公開鍵一覧の１行目を取得
 # - 取得先は： https://github.com/<user name>.keys
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
-echo -n "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
+printf "%s" "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
 if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
     echo "NG：公開鍵を取得・保存できませんでした。"
@@ -112,7 +112,7 @@ echo "OK"
 # - 参考URL ：
 #   - https://qiita.com/drobune/items/bf5d689eff7f69ed6866
 #   - https://qiita.com/connvoi_tyou/items/3e86b6b68c3f398b3244
-echo -n "RSA 形式の公開鍵を PKCS8 形式に変換中 ... "
+printf "%s" "RSA 形式の公開鍵を PKCS8 形式に変換中 ... "
 
 if ! ssh-keygen -f "$PATHPUBKEY" -e -m pkcs8 >"${PATHPUBKEY}.pkcs8"; then
     echo "NG：RSA -> PKCS8 変換中にエラーが発生しました。"
@@ -123,7 +123,7 @@ echo "OK"
 # 電子署名の検証
 # --------------
 # - 参考URL ： https://qiita.com/kunichiko/items/3c0b1a2915e9dacbd4c1
-echo -n "ファイル ${INPUTFILE} の署名ファイルを検証中 ... "
+printf "%s" "ファイル ${INPUTFILE} の署名ファイルを検証中 ... "
 
 if ! openssl dgst \
     -sha1 \

--- a/bin/verify
+++ b/bin/verify
@@ -83,7 +83,7 @@ PATHPUBKEY="${TMPDIR}/${USERNAME}.pub"
 # ユーザの GitHub の公開鍵一覧の１行目を取得
 # - 取得先は： https://github.com/<user name>.keys
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
-echo -n "- ${USERNAME} の GitHub 上の公開鍵を取得中 ... "
+printf "%s" "- ${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
 if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
     echo "NG：公開鍵を取得・保存できませんでした。"
@@ -96,7 +96,7 @@ echo "OK"
 # - 参考URL ：
 #   - https://qiita.com/drobune/items/bf5d689eff7f69ed6866
 #   - https://qiita.com/connvoi_tyou/items/3e86b6b68c3f398b3244
-echo -n "- RSA 形式の公開鍵を PKCS8 形式に変換中 ... "
+printf "%s" "- RSA 形式の公開鍵を PKCS8 形式に変換中 ... "
 
 if ! ssh-keygen -f "$PATHPUBKEY" -e -m pkcs8 >"${PATHPUBKEY}.pkcs8"; then
     echo "NG：RSA -> PKCS8 変換中にエラーが発生しました。"
@@ -107,7 +107,7 @@ echo "OK"
 # 電子署名の検証
 # --------------
 # - 参考URL ： https://qiita.com/kunichiko/items/3c0b1a2915e9dacbd4c1
-echo -n "- ファイル ${VERIFYFILE} の署名ファイルを検証中 ... "
+printf "%s" "- ファイル ${VERIFYFILE} の署名ファイルを検証中 ... "
 
 if ! openssl dgst -sha1 \
     -verify "${PATHPUBKEY}.pkcs8" \


### PR DESCRIPTION
## 関連

* issue #43 [POSIX 準拠] echo -n "$foo" を printf "%s" "$foo" に
* discussions [非POSIXコマンドの書き換え案](https://github.com/Qithub-BOT/QiiCipher/discussions/39#discussioncomment-829720)
* PR #48 macOS でのテストを追加

## 対策内容

POSIX 準拠のためのリファクタリングがメイン

* `echo -n "$foo"` を `printf "%s" "$foo"` に変更
  * 現状、変数がないものも、一律 `printf "%s" ` をつけるようにしています
  * 将来変更して変数を埋め込む場合にも修正が不要になるため
  * また、 `echo -n "- xxxx"` を `printf "- xxxx"` とすると、不正なオプションと判断されることがあるため、一律 `"%s"` をつけるほうが安全と思われる
* dearchive の `echo "$1" | md5sum` を `printf "%s" "$1" | md5sum` に変更（不要な改行コードを取り除く）
