### PR TITLE
curlの代替としてwget/fetchをサポート

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ GitHub 上の公開鍵を使ってファイルの暗号化と署名確認、ロ�
 - 必須コマンド
   - `openssl` コマンド: 暗号化・復号・ランダム値取得などに [OpenSSL](https://ja.wikipedia.org/wiki/OpenSSL) コマンドが必要です。
   - `ssh-keygen` コマンド: 公開鍵・秘密鍵の作成に必要です。[OpenSSH](https://ja.wikipedia.org/wiki/OpenSSH) と一緒にインストールされますが、インストールされていない場合は `openssh` もしくは `openssh-keygen` などでインストールしてください。
-  - `curl` コマンド: 現在のバージョンは `wget` に対応しておりません。
+  - コンテンツ取得コマンド: 現在のバージョンでは `curl` `wget` `fetch` のいずれかが必要です。
 
 ---
 

--- a/bin/checkkeylength
+++ b/bin/checkkeylength
@@ -29,6 +29,19 @@ getRandStr() {
     openssl rand -hex 16 2>&1
 }
 
+catURL() {
+    if type curl 1>/dev/null 2>/dev/null; then
+        curl -s "$1"
+    elif type wget 1>/dev/null 2>/dev/null; then
+        wget -nv -O - "$1"
+    elif type fetch 1>/dev/null 2>/dev/null; then
+        fetch -q -o - "$1"
+    else
+        echo >&2 'データ取得に必要なコマンド(curl/wget/fetch)がインストールされていません。'
+        exit 1
+    fi
+}
+
 # コマンド引数取得
 # ----------------
 USERNAME=$1
@@ -56,7 +69,7 @@ PATHPUBKEY="/tmp/${USERNAME}.${RAND}.pub"
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
 printf "%s" "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
-if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
+if ! catURL "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
     echo "NG：公開鍵を取得・保存できませんでした。"
     exit 1
 fi

--- a/bin/enc
+++ b/bin/enc
@@ -21,12 +21,6 @@ if ! type openssl 2>/dev/null 1>/dev/null; then
     exit 1
 fi
 
-if ! type curl 2>/dev/null 1>/dev/null; then
-    echo >&2 'データ取得に必要な curl コマンドがインストールされていません。'
-
-    exit 1
-fi
-
 # -----------------------------------------------------------------------------
 #  Main
 # -----------------------------------------------------------------------------
@@ -50,6 +44,19 @@ fi
 
 getRandStr() {
     openssl rand -hex 16 2>&1
+}
+
+catURL() {
+    if type curl 1>/dev/null 2>/dev/null; then
+        curl -s "$1"
+    elif type wget 1>/dev/null 2>/dev/null; then
+        wget -nv -O - "$1"
+    elif type fetch 1>/dev/null 2>/dev/null; then
+        fetch -q -o - "$1"
+    else
+        echo >&2 'データ取得に必要なコマンド(curl/wget/fetch)がインストールされていません。'
+        exit 1
+    fi
 }
 
 # コマンド引数取得
@@ -86,7 +93,7 @@ PATHPUBKEY="/tmp/${USERNAME}.${RAND}.pub"
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
 printf "%s" "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
-if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
+if ! catURL "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
     echo >&2 "NG：公開鍵を取得・保存できませんでした。"
     exit 1
 fi

--- a/bin/sign
+++ b/bin/sign
@@ -36,6 +36,19 @@ getRandStr() {
     openssl rand -hex 16 2>&1
 }
 
+catURL() {
+    if type curl 1>/dev/null 2>/dev/null; then
+        curl -s "$1"
+    elif type wget 1>/dev/null 2>/dev/null; then
+        wget -nv -O - "$1"
+    elif type fetch 1>/dev/null 2>/dev/null; then
+        fetch -q -o - "$1"
+    else
+        echo >&2 'データ取得に必要なコマンド(curl/wget/fetch)がインストールされていません。'
+        exit 1
+    fi
+}
+
 # コマンド引数取得
 # ----------------
 USERNAME=$1
@@ -93,7 +106,7 @@ PATHPUBKEY="/tmp/${USERNAME}.${RAND}.pub"
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
 printf "%s" "${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
-if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
+if ! catURL "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
     echo "NG：公開鍵を取得・保存できませんでした。"
     exit 1
 fi

--- a/bin/verify
+++ b/bin/verify
@@ -34,6 +34,19 @@ getRandStr() {
     openssl rand -hex 16 2>&1
 }
 
+catURL() {
+    if type curl 1>/dev/null 2>/dev/null; then
+        curl -s "$1"
+    elif type wget 1>/dev/null 2>/dev/null; then
+        wget -nv -O - "$1"
+    elif type fetch 1>/dev/null 2>/dev/null; then
+        fetch -q -o - "$1"
+    else
+        echo >&2 'データ取得に必要なコマンド(curl/wget/fetch)がインストールされていません。'
+        exit 1
+    fi
+}
+
 # コマンド引数取得
 # ----------------
 VERIFYFILE="$1"
@@ -78,7 +91,7 @@ PATHPUBKEY="${TMPDIR}/${USERNAME}.pub"
 # - 参考URL ： https://qiita.com/m0r1/items/af16c41475d493ab6774
 printf "%s" "- ${USERNAME} の GitHub 上の公開鍵を取得中 ... "
 
-if ! curl -s "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
+if ! catURL "https://github.com/${USERNAME}.keys" | head -n 1 >"$PATHPUBKEY"; then
     echo "NG：公開鍵を取得・保存できませんでした。"
     exit 1
 fi


### PR DESCRIPTION
## 関連

* issue #55 wget で curl の代替可能に
* discussion #39  非POSIXコマンドの書き換え案

## 対応

* curl が使用可能なら curl を使用する
* curl が使用不可で、 wget が使用可能なら wget を使用する
* curl / wget が使用不可で、 fetch が使用可能なら fetch を使用する
  * fetch は FreeBSD などで使われているみたい

## その他

* 単体テストのモックは curl のみ対応している（変更していない） その関係もあり使用可能なコマンドは curl → wget → fetch の順番にチェックをしている
* curl /wget / fetch 以外にも、類似のコマンドはあるみたいですが（ Kurly, HTTPie, ...）、現状はこの３つの実を対応している